### PR TITLE
Add a changelog section, common to both variants

### DIFF
--- a/common-content-dataflow/modules/ROOT/partials/changelog.adoc
+++ b/common-content-dataflow/modules/ROOT/partials/changelog.adoc
@@ -2,76 +2,76 @@
 
 This page lists changes to the Dataflow Flex Template for BigQuery and/or Google Cloud to Neo4j.
 
-== 2025-06-10-01_RC00
+== Release 2025-06-10-01_RC00
 
 * Add support to see get underlying Neo4j driver log output
 
-== 2025-01-26-00_RC00
+== Release 2025-01-26-00_RC00
 
 * Add support for calendar based version names of the Neo4j driver
 
-== 2025-01-22-01_RC00
+== Release 2025-01-22-01_RC00
 
 * Updated Neo4j driver version from v4.4.18 to v5.27.0
 
-== 2025-01-14-00_RC00
+== Release 2025-01-14-00_RC00
 
 * Re-added node target's existance constraint
 
-== 2025-01-07-00_RC01
+== Release 2025-01-07-00_RC01
 
 * Remove node target's existance constraint
 * Fix an issue with custom Cypher queries
 * Further minor bugfixes
 
-== 2024-12-10-00_RC00
+== Release 2024-12-10-00_RC00
 
 * Added support for BigQuery properties 'query_temp_project' and 'query_temp_dataset'
 
-== 2024-11-26-00_RC00
+== Release 2024-11-26-00_RC00
 
 * Improved stability of node matching
 * Improved stability of YAML parsing
 
-== 2024-11-19-00_RC00
+== Release 2024-11-19-00_RC00
 
 * Add YAML support when parsing specification
 
 
-== 2024-11-12-00_RC00
+== Release 2024-11-12-00_RC00
 
 * Empty strings are now treated as null values when importing from CSV files.
 
 
-== 2024-09-18-00_RC00
+== Release 2024-09-18-00_RC00
 
 * Introduce new import specification
 
-== 2024-08-13-00_RC00
+== Release 2024-08-13-00_RC00
 
 * Fix serialization issues with Cypher actions
 
-== 2024-05-28-00_RC00
+== Release 2024-05-28-00_RC00
 
 * Fix a bug regarding overlapping names between source fields and nodes/relationships
 * Stability improvements and typo fixes
 
-== 2024-04-02-00_RC00
+== Release 2024-04-02-00_RC00
 
 * Automatically use Neo4j version/edition for reset and schema generation
 
-== 2024-03-21-00_RC00
+== Release 2024-03-21-00_RC00
 
 * Extended metadata for imports
 * Extended support for ISO date times
 * Stability improvements
 
-== 2024-03-12-00_RC00
+== Release 2024-03-12-00_RC00
 
 * Improvements to parallelism
 * Add metadata for transactions and all import steps
 * Include user agent when connecting to Neo4j
 
-== 2024-01-30-01_RC00
+== Release 2024-01-30-01_RC00
 
 This is a maintenance release which provides updated dependencies.

--- a/common-content-dataflow/modules/ROOT/partials/changelog.adoc
+++ b/common-content-dataflow/modules/ROOT/partials/changelog.adoc
@@ -1,0 +1,28 @@
+= Changelog
+
+This page lists changes to the TESTING_TO_SEE_OK.
+
+== Version 5.1.13
+
+[cols="1,2", options="header"]
+|===
+| Feature | Details
+
+a|
+label:bug[]
+label:fixed[]
+
+Introduce `neo4j.query.force-maps-as-struct`
+| For the source query strategy, users can now control whether maps with homogeneous value types are encoded as structs or maps.
+|===
+== Version 5.1.12
+
+This is a maintenance release which provides updated dependencies.
+
+== Version 5.1.11
+
+This is a maintenance release which provides updated dependencies.
+
+== Version 5.1.10
+
+This is a maintenance release which provides updated dependencies.

--- a/common-content-dataflow/modules/ROOT/partials/changelog.adoc
+++ b/common-content-dataflow/modules/ROOT/partials/changelog.adoc
@@ -9,14 +9,15 @@ To check the release status of https://cloud.google.com/compute/docs/regions-zon
 
 == Release 2025-06-10-01_RC00
 
-* Add support to see underlying Neo4j driver's log-output
+* Add support to see underlying Neo4j driver's Bolt logs
 
 == Release 2025-01-26-00_RC00
 
-* Add support for calendar based version names of the Neo4j driver
+* Add support for calendar-based version names of the Neo4j database
 
 == Release 2025-01-22-01_RC00
 
+* Switch to Java 17
 * Updated Neo4j driver version from v4.4.18 to v5.27.0
 
 == Release 2025-01-14-00_RC00
@@ -33,24 +34,17 @@ To check the release status of https://cloud.google.com/compute/docs/regions-zon
 
 * Added support for BigQuery properties 'query_temp_project' and 'query_temp_dataset'
 
-== Release 2024-11-26-00_RC00
-
-* Improved stability of node matching
-* Improved stability of YAML parsing
-
 == Release 2024-11-19-00_RC00
 
 * Add YAML support when parsing specification
-
 
 == Release 2024-11-12-00_RC00
 
 * Empty strings are now treated as null values when importing from CSV files.
 
-
 == Release 2024-09-18-00_RC00
 
-* Introduce new import specification
+* Introduce new import specification (https://github.com/neo4j/import-spec)
 
 == Release 2024-08-13-00_RC00
 
@@ -59,17 +53,11 @@ To check the release status of https://cloud.google.com/compute/docs/regions-zon
 == Release 2024-05-28-00_RC00
 
 * Fix a bug regarding overlapping names between source fields and nodes/relationships
-* Stability improvements and typo fixes
-
-== Release 2024-04-02-00_RC00
-
-* Automatically use Neo4j version/edition for reset and schema generation
 
 == Release 2024-03-21-00_RC00
 
-* Extended metadata for imports
-* Extended support for ISO date times
-* Stability improvements
+* Allow users to specify only the first _n_ columns of a text file source
+* Improve temporal type support
 
 == Release 2024-03-12-00_RC00
 
@@ -77,6 +65,37 @@ To check the release status of https://cloud.google.com/compute/docs/regions-zon
 * Add metadata for transactions and all import steps
 * Include user agent when connecting to Neo4j
 
-== Release 2024-01-30-01_RC00
+== Release 2023-12-12-00_RC00
 
-This is a maintenance release which provides updated dependencies.
+* Allow connection information to be read from Secret Manager
+* Add support for all authentication types
+
+== Release 2023-09-19-00_RC00
+
+* Verify Neo4j connectivity early
+* Improve error message when database reset fails
+* Fix support for boolean values
+
+== Release 2023-08-15-00_RC00
+
+* Fix connection leak when creating indices/constraints
+* Support multiple key definitions in "transposed" syntax
+
+== Release 2023-07-25-00_RC00
+
+* Optimize database query
+* Remove unused settings (`automap`, `default`, `options`)
+
+== Release 2023-07-18-00_RC00
+
+* Fixes mix-up between parallelism and batch size settings
+* Fixes Neo4j driver usages
+    * Properly close driver and sessions
+    * Rely on result consumption API instead of explicit iteration
+* Support constraints and indices for relationship targets
+* Allow start/end nodes to be merged instead of created
+
+
+== Release 2022-10-18-00_RC00
+
+Hello world! Initial release of the template.

--- a/common-content-dataflow/modules/ROOT/partials/changelog.adoc
+++ b/common-content-dataflow/modules/ROOT/partials/changelog.adoc
@@ -32,7 +32,7 @@ To check the release status of https://cloud.google.com/compute/docs/regions-zon
 
 == Release 2024-12-10-00_RC00
 
-* Added support for BigQuery properties 'query_temp_project' and 'query_temp_dataset'
+* Added support for BigQuery properties `query_temp_project` and `query_temp_dataset`
 
 == Release 2024-11-19-00_RC00
 

--- a/common-content-dataflow/modules/ROOT/partials/changelog.adoc
+++ b/common-content-dataflow/modules/ROOT/partials/changelog.adoc
@@ -5,7 +5,7 @@ This page lists changes to the Dataflow Flex Template for BigQuery and/or Google
 You can check the deployment status of a release by running `gsutil ls gs://dataflow-templates/`.
 
 Releases are gradually deployed, some regions may be updated before others.
-To check the release status of https://cloud.google.com/compute/docs/regions-zones[a particular region], you can run `gsutil ls gs://dataflow-templates-${region}/` (e.g. `gsutil ls gs://dataflow-templates-europe-west2/`).
+To check the release status of https://cloud.google.com/compute/docs/regions-zones[a particular region], you can run `gsutil ls gs://dataflow-templates-$\{region}/` (e.g. `gsutil ls gs://dataflow-templates-europe-west2/`).
 
 == Release 2025-06-10-01_RC00
 

--- a/common-content-dataflow/modules/ROOT/partials/changelog.adoc
+++ b/common-content-dataflow/modules/ROOT/partials/changelog.adoc
@@ -2,6 +2,11 @@
 
 This page lists changes to the Dataflow Flex Template for BigQuery and/or Google Cloud to Neo4j.
 
+You can check the deployment status of a release by running `gsutil ls gs://dataflow-templates/`.
+
+Releases are gradually deployed, some regions may be updated before others.
+To check the release status of https://cloud.google.com/compute/docs/regions-zones[a particular region], you can run `gsutil ls gs://dataflow-templates-${region}/` (e.g. `gsutil ls gs://dataflow-templates-europe-west2/`).
+
 == Release 2025-06-10-01_RC00
 
 * Add support to see underlying Neo4j driver's log-output

--- a/common-content-dataflow/modules/ROOT/partials/changelog.adoc
+++ b/common-content-dataflow/modules/ROOT/partials/changelog.adoc
@@ -44,7 +44,7 @@ To check the release status of https://cloud.google.com/compute/docs/regions-zon
 
 == Release 2024-09-18-00_RC00
 
-* Introduce new import specification (https://github.com/neo4j/import-spec)
+* Introduce new import specification (https://github.com/neo4j/import-spec), on which Dataflow templates base their import specifications.
 
 == Release 2024-08-13-00_RC00
 

--- a/common-content-dataflow/modules/ROOT/partials/changelog.adoc
+++ b/common-content-dataflow/modules/ROOT/partials/changelog.adoc
@@ -1,6 +1,6 @@
 = Changelog
 
-This page lists changes to the TESTING_TO_SEE_OK.
+This page lists changes to the Dataflow Flex Template for BigQuery and/or Google Cloud to Neo4j.
 
 == Version 5.1.13
 

--- a/common-content-dataflow/modules/ROOT/partials/changelog.adoc
+++ b/common-content-dataflow/modules/ROOT/partials/changelog.adoc
@@ -4,64 +4,74 @@ This page lists changes to the Dataflow Flex Template for BigQuery and/or Google
 
 == 2025-06-10-01_RC00
 
+* Add support to see get underlying Neo4j driver log output
 
 == 2025-01-26-00_RC00
 
+* Add support for calendar based version names of the Neo4j driver
 
 == 2025-01-22-01_RC00
 
+* Updated Neo4j driver version from v4.4.18 to v5.27.0
 
 == 2025-01-14-00_RC00
 
+* Re-added node target's existance constraint
 
 == 2025-01-07-00_RC01
 
+* Remove node target's existance constraint
+* Fix an issue with custom Cypher queries
+* Further minor bugfixes
 
 == 2024-12-10-00_RC00
 
+* Added support for BigQuery properties 'query_temp_project' and 'query_temp_dataset'
 
 == 2024-11-26-00_RC00
 
+* Improved stability of node matching
+* Improved stability of YAML parsing
 
 == 2024-11-19-00_RC00
+
+* Add YAML support when parsing specification
 
 
 == 2024-11-12-00_RC00
 
-
-== 2024-10-29-00_RC00
+* Empty strings are now treated as null values when importing from CSV files.
 
 
 == 2024-09-18-00_RC00
 
+* Introduce new import specification
 
 == 2024-08-13-00_RC00
 
+* Fix serialization issues with Cypher actions
 
 == 2024-05-28-00_RC00
 
-
-== 2024-05-13-00_RC00
-
-
-== 2024-05-28-00_RC00
-
+* Fix a bug regarding overlapping names between source fields and nodes/relationships
+* Stability improvements and typo fixes
 
 == 2024-04-02-00_RC00
 
+* Automatically use Neo4j version/edition for reset and schema generation
 
 == 2024-03-21-00_RC00
 
+* Extended metadata for imports
+* Extended support for ISO date times
+* Stability improvements
 
 == 2024-03-12-00_RC00
 
-
-== 2024-03-21-00_RC00
-
-
-== 2024-03-12-00_RC00
-
+* Improvements to parallelism
+* Add metadata for transactions and all import steps
+* Include user agent when connecting to Neo4j
 
 == 2024-01-30-01_RC00
 
-
+This is a maintenance release which provides updated dependencies.

--- a/common-content-dataflow/modules/ROOT/partials/changelog.adoc
+++ b/common-content-dataflow/modules/ROOT/partials/changelog.adoc
@@ -4,7 +4,7 @@ This page lists changes to the Dataflow Flex Template for BigQuery and/or Google
 
 == Release 2025-06-10-01_RC00
 
-* Add support to see get underlying Neo4j driver log output
+* Add support to see underlying Neo4j driver's log-output
 
 == Release 2025-01-26-00_RC00
 
@@ -16,13 +16,13 @@ This page lists changes to the Dataflow Flex Template for BigQuery and/or Google
 
 == Release 2025-01-14-00_RC00
 
-* Re-added node target's existance constraint
+* Re-added node target's existence constraint
 
 == Release 2025-01-07-00_RC01
 
-* Remove node target's existance constraint
+* Remove node target's existence constraint
 * Fix an issue with custom Cypher queries
-* Further minor bugfixes
+* Further minor bug-fixes
 
 == Release 2024-12-10-00_RC00
 

--- a/common-content-dataflow/modules/ROOT/partials/changelog.adoc
+++ b/common-content-dataflow/modules/ROOT/partials/changelog.adoc
@@ -2,27 +2,66 @@
 
 This page lists changes to the Dataflow Flex Template for BigQuery and/or Google Cloud to Neo4j.
 
-== Version 5.1.13
+== 2025-06-10-01_RC00
 
-[cols="1,2", options="header"]
-|===
-| Feature | Details
 
-a|
-label:bug[]
-label:fixed[]
+== 2025-01-26-00_RC00
 
-Introduce `neo4j.query.force-maps-as-struct`
-| For the source query strategy, users can now control whether maps with homogeneous value types are encoded as structs or maps.
-|===
-== Version 5.1.12
 
-This is a maintenance release which provides updated dependencies.
+== 2025-01-22-01_RC00
 
-== Version 5.1.11
 
-This is a maintenance release which provides updated dependencies.
+== 2025-01-14-00_RC00
 
-== Version 5.1.10
 
-This is a maintenance release which provides updated dependencies.
+== 2025-01-07-00_RC01
+
+
+== 2024-12-10-00_RC00
+
+
+== 2024-11-26-00_RC00
+
+
+== 2024-11-19-00_RC00
+
+
+== 2024-11-12-00_RC00
+
+
+== 2024-10-29-00_RC00
+
+
+== 2024-09-18-00_RC00
+
+
+== 2024-08-13-00_RC00
+
+
+== 2024-05-28-00_RC00
+
+
+== 2024-05-13-00_RC00
+
+
+== 2024-05-28-00_RC00
+
+
+== 2024-04-02-00_RC00
+
+
+== 2024-03-21-00_RC00
+
+
+== 2024-03-12-00_RC00
+
+
+== 2024-03-21-00_RC00
+
+
+== 2024-03-12-00_RC00
+
+
+== 2024-01-30-01_RC00
+
+

--- a/common-content-dataflow/modules/ROOT/partials/changelog.adoc
+++ b/common-content-dataflow/modules/ROOT/partials/changelog.adoc
@@ -6,6 +6,7 @@ You can check the deployment status of a release by running `gsutil ls gs://data
 
 Releases are gradually deployed, some regions may be updated before others.
 To check the release status of https://cloud.google.com/compute/docs/regions-zones[a particular region], you can run `gsutil ls gs://dataflow-templates-$\{region}/` (e.g. `gsutil ls gs://dataflow-templates-europe-west2/`).
+It is not possible to run any other version than the *latest* version of your region.
 
 == Release 2025-06-10-01_RC00
 
@@ -13,7 +14,7 @@ To check the release status of https://cloud.google.com/compute/docs/regions-zon
 
 == Release 2025-01-26-00_RC00
 
-* Add support for calendar-based version names of the Neo4j database
+* Support for self-managed deployments of Neo4j versions 2025.x
 
 == Release 2025-01-22-01_RC00
 
@@ -27,7 +28,7 @@ To check the release status of https://cloud.google.com/compute/docs/regions-zon
 == Release 2025-01-07-00_RC01
 
 * Remove node target's existence constraint
-* Fix an issue with custom Cypher queries
+* Fix an edge case where some custom Cypher queries could fetch data incorrectly, causing null-pointer exceptions
 * Further minor bug-fixes
 
 == Release 2024-12-10-00_RC00
@@ -40,11 +41,11 @@ To check the release status of https://cloud.google.com/compute/docs/regions-zon
 
 == Release 2024-11-12-00_RC00
 
-* Empty strings are now treated as null values when importing from CSV files.
+* Empty strings are now treated as null values when importing from CSV files
 
 == Release 2024-09-18-00_RC00
 
-* Introduce new import specification (https://github.com/neo4j/import-spec), on which Dataflow templates base their import specifications.
+* Introduce new import specification (https://github.com/neo4j/import-spec), on which Dataflow templates base their import specifications
 
 == Release 2024-08-13-00_RC00
 

--- a/common-content-dataflow/modules/ROOT/partials/changelog.adoc
+++ b/common-content-dataflow/modules/ROOT/partials/changelog.adoc
@@ -6,7 +6,7 @@ You can check the deployment status of a release by running `gsutil ls gs://data
 
 Releases are gradually deployed, some regions may be updated before others.
 To check the release status of https://cloud.google.com/compute/docs/regions-zones[a particular region], you can run `gsutil ls gs://dataflow-templates-$\{region}/` (e.g. `gsutil ls gs://dataflow-templates-europe-west2/`).
-It is not possible to run any other version than the *latest* version of your region.
+It is not possible to run any version other than the *latest* one deployed in a given region.
 
 == Release 2025-06-10-01_RC00
 

--- a/dataflow-bigquery/modules/ROOT/content-nav.adoc
+++ b/dataflow-bigquery/modules/ROOT/content-nav.adoc
@@ -3,3 +3,4 @@
 * xref:job-specification.adoc[]
 * xref:run-job.adoc[]
 * xref:cli.adoc[]
+* xref:changelog.adoc[]

--- a/dataflow-bigquery/modules/ROOT/pages/changelog.adoc
+++ b/dataflow-bigquery/modules/ROOT/pages/changelog.adoc
@@ -1,0 +1,1 @@
+include::{common}:partial$changelog.adoc[]

--- a/dataflow-google-cloud/modules/ROOT/content-nav.adoc
+++ b/dataflow-google-cloud/modules/ROOT/content-nav.adoc
@@ -3,3 +3,4 @@
 * xref:job-specification.adoc[]
 * xref:run-job.adoc[]
 * xref:cli.adoc[]
+* xref:changelog.adoc[]

--- a/dataflow-google-cloud/modules/ROOT/pages/changelog.adoc
+++ b/dataflow-google-cloud/modules/ROOT/pages/changelog.adoc
@@ -1,0 +1,1 @@
+include::{common}:partial$changelog.adoc[]


### PR DESCRIPTION
Of course there are some differences between BigQuery and Google Cloud in terms 
of documentation. But I decided for simplicity to have the same changelog for
both -- it's the same source code for both. Interpreted both git history and code 
changes to figure out major differences between the different releases.

[Trello Card](https://trello.com/c/Byf10wFf/1203-dataflow-flex-template-release-notes)