### PR TITLE
Add start page

### DIFF
--- a/dataflow/antora.yml
+++ b/dataflow/antora.yml
@@ -1,0 +1,6 @@
+name: dataflow
+title: Dataflow Flex Templates
+version: '1'
+start_page: ROOT:index.adoc
+nav:
+- modules/ROOT/content-nav.adoc

--- a/dataflow/modules/ROOT/content-nav.adoc
+++ b/dataflow/modules/ROOT/content-nav.adoc
@@ -1,0 +1,1 @@
+* xref:index.adoc[]

--- a/dataflow/modules/ROOT/pages/index.adoc
+++ b/dataflow/modules/ROOT/pages/index.adoc
@@ -1,0 +1,39 @@
+= Dataflow flex templates
+:page-role: dataflow
+:page-layout: docs-home
+:page-toclevels: -1
+
+
+
+[NOTE]
+--
+This page is published only as part of local builds and PR previews.
+It is not included in the published Neo4j drivers documentation.
+--
+
+
+== Dataflow flex templates
+
+
+=== Bigquery
+
+[.category]
+dataflow
+
+[.icon]
+image:{neo4j-docs-base-uri}/_images/icon-bigquery.svg[]
+
+[.link]
+xref:dataflow-bigquery:ROOT:index.adoc[Guide]
+
+
+=== Google Cloud
+
+[.category]
+dataflow
+
+[.icon]
+image:{neo4j-docs-base-uri}/_images/icon-googlecloud.svg[]
+
+[.link]
+xref:dataflow-google-cloud:ROOT:index.adoc[Guide]

--- a/preview.yml
+++ b/preview.yml
@@ -1,13 +1,14 @@
 site:
   title: Neo4j Google Dataflow Template
   url: https://neo4j.com/docs/
-#  start_page: dataflow-bigquery:ROOT:index.adoc
+  start_page: dataflow:ROOT:index.adoc
 
 content:
   sources:
   - url: ./
     branches: HEAD
     start_paths:
+    - dataflow
     - dataflow-google-cloud
     - dataflow-bigquery
     - common-content-dataflow


### PR DESCRIPTION
Fixes an issue in the PR deploys where the GHA workflow can't figure out which folder to extract from docs.zip (because there's no _*/index.html_ file, which is what the workflow is looking for in order to determine which folder contains the docs)