### PR TITLE
Accessibility: add alt text to images

### DIFF
--- a/common-content-dataflow/modules/ROOT/partials/job-specification.adoc
+++ b/common-content-dataflow/modules/ROOT/partials/job-specification.adoc
@@ -48,7 +48,7 @@ Both entities and relationships have extra details attached to each of them.
 The data is sourced from the following files: xref:common-content-dataflow:ROOT:attachment$persons.csv[persons.csv], xref:common-content-dataflow:ROOT:attachment$movies.csv[movies.csv], xref:common-content-dataflow:ROOT:attachment$acted_in.csv[acted_in.csv], xref:common-content-dataflow:ROOT:attachment$directed.csv[directed.csv].
 
 [.shadow]
-image::{common}:image$movies-model.png[width=400]
+image::{common}:image$movies-model.png["Graph data model showing a Person node connected to a Movie node by two relationships, ACTED_IN and DIRECTED",width=400]
 
 The next sections break it down and provide in-context information for each part.
 We recommend reading this guide side by side with the job specification example.

--- a/common-content-dataflow/modules/ROOT/partials/prerequisites.adoc
+++ b/common-content-dataflow/modules/ROOT/partials/prerequisites.adoc
@@ -139,7 +139,7 @@ The link:https://console.cloud.google.com/dataflow[Google Dataflow] job glues al
 You need to craft a _job specification_ file to provide Dataflow with all the information it needs to load the data into Neo4j.
 
 [.shadow]
-image::{common}:image$google-dataflow.jpg[width=400]
+image::{common}:image$google-dataflow.jpg["Diagram of the Google Cloud to Neo4j Dataflow Flex Template: file and SQL data sources feed into Google Dataflow, which uses a job specification to import the data into Neo4j",width=400]
 
 [NOTE]
 All Google-related resources (Cloud project, Cloud Storage buckets, Dataflow job) should either belong to the same account, or to one which the Dataflow job has permissions to access.

--- a/common-content-dataflow/modules/ROOT/partials/run-job.adoc
+++ b/common-content-dataflow/modules/ROOT/partials/run-job.adoc
@@ -34,4 +34,4 @@ When launching your job, ensure you align your regional settings:
 ====
 
 [.shadow]
-image::{common}:image$dataflow-job-example.png[width=600]
+image::{common}:image$dataflow-job-example.png["Screenshot of the Google Cloud Dataflow 'Create job from template' page, filled in with a job name, the 'Google Cloud to Neo4j' template, and the paths to the job specification and Neo4j connection metadata files",width=600]

--- a/dataflow-google-cloud/modules/ROOT/pages/job-specification.adoc
+++ b/dataflow-google-cloud/modules/ROOT/pages/job-specification.adoc
@@ -52,7 +52,7 @@ The default column delimiter and line separator are set depending on the specifi
 To retrieve the Google Storage location of a file in a Cloud bucket, expand the file options through the three dots on the right, and choose `Copy gsutil URI`.
 
 [.shadow]
-image::image$google-cloud-file-url.png[width=600]
+image::image$google-cloud-file-url.png["Screenshot of the Google Cloud Storage file options menu with the 'Copy gsutil URI' option highlighted",width=600]
 ====
 +
 - `format` (string) -- The format of the provided CSV file. +


### PR DESCRIPTION
## What

Added descriptive alt text to all 4 images in the Dataflow connector docs (WCAG 1.1.1). None had alt text before.

| Image | File |
|---|---|
| Person→Movie graph data model | `common-content-dataflow` job-specification |
| Google Cloud to Neo4j Dataflow Flex Template diagram | `common-content-dataflow` prerequisites |
| "Create job from template" screenshot | `common-content-dataflow` run-job |
| "Copy gsutil URI" menu screenshot | `dataflow-google-cloud` job-specification |

Existing `width`/`[.shadow]` attributes preserved; alt text added as the first (double-quoted) positional attribute so embedded commas render correctly.

## Verification

Rendered the changed pages with `asciidoctor` and confirmed each `<img>` emits the full `alt` text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)