### PR TITLE
DOCOPS-176 Add page-tabs attributes to publish playbook

### DIFF
--- a/publish.yml
+++ b/publish.yml
@@ -44,6 +44,8 @@ asciidoc:
   - "@neo4j-antora/antora-add-notes"
   - "@neo4j-antora/mark-terms"
   attributes:
+    page-tabs: drivers-apis@
+    page-tabs-index: 100
     page-theme: docs
     page-type: Docs
     page-search-type: Docs


### PR DESCRIPTION
Adds `page-tabs` and `page-tabs-index` to `publish.yml`:

```yaml
page-tabs: drivers-apis@
page-tabs-index: 100
```

Places this docset in the `drivers-apis` tab of the aggregated tabbed navigation, at the
position matching its order in the Docs menu on neo4j.com/docs. The value is
soft-set with a trailing `@` so it can be overridden.
